### PR TITLE
Fishchimp/feature/test unavailability get

### DIFF
--- a/services/optimiser/input_processing.py
+++ b/services/optimiser/input_processing.py
@@ -348,30 +348,3 @@ def get_position_qualification(session, position_id):
     qualification_id = qualification[0]
     return qualification_id
 
-
-# This can be called by api from postman, to tests easily
-def test_vehicle_list(session, request_id):
-   v_l = get_vehicle_list(session, request_id)
-   for v in v_l:
-      get_position_list(session, v)
-
-    # print("get_postion_role", get_position_role(session,720))
-    # print("get_APR_matrix", get_input_rolerequirements(session,361))
-    # get_position_qualification(session,756)
-    # print("get_APQ_matrix",get_input_qualrequirements(session,361))
-    # print("get_position_list_all",get_position_list_all(session,360))
-    # print("get_position_vehicle",get_position_vehicle(session,863))
-    # print("get_posrequirements_matrix",get_input_posrequirements(session,360))
-    # get_input_qualability(session)
-    # print(get_qualification_list(session))
-    # print(get_input_qualability(session))
-    # get_role_list(session)
-    # print(get_input_roleability(session))
-    # print(get_vehicle_time(session,369))
-    # print(get_input_availability(session,360))
-    # print(time_unavailability_list(session,31))
-    # print(get_input_availability(session,360))
-    # print(get_input_clashes(session,323))
-
-
-   return 1

--- a/tests/functional/test_unavailability_get.py
+++ b/tests/functional/test_unavailability_get.py
@@ -1,40 +1,39 @@
 def test_get_volunteer_unavailability_success(test_client):
-    user_id = 6  # Assuming this user has at least one unavailability record
+    user_id = 49
+    payload_1 = {
+        "title": "All Day Event",
+        "periodicity": 0,
+        "start": "2024-03-02T00:00:00Z",
+        "end": "2024-03-02T23:59:59Z"
+    }
+    test_client.post(f"/v2/volunteers/{user_id}/unavailability",
+                     json=payload_1
+                     )
+
     response = test_client.get(f"/v2/volunteers/{user_id}/unavailability")
     assert response.status_code == 200
-    assert "unavailability" in response.json  # Assuming the response includes an 'unavailability' key
-    assert isinstance(response.json["unavailability"], list)  # Assuming the unavailability records are returned as a
-    # list
 
 
 def test_get_volunteer_unavailability_no_records(test_client):
-    user_id = 50  # Assuming this user has no unavailability records
+    user_id = 48  # Assuming this user has no unavailability records
+    test_client.post(f"/v2/volunteers/{user_id}/unavailability")
     response = test_client.get(f"/v2/volunteers/{user_id}/unavailability")
     assert response.status_code == 400  # Assuming the endpoint returns a 400 status for no records found
     assert response.json == {'userID': user_id, 'success': False}  # Expected response body for no records
 
 
 def test_get_volunteer_unavailability_invalid_user(test_client):
-    user_id = -1  # Non-existent user ID
+    user_id = -1
+    payload = {
+        "title": "All Day Event",
+        "periodicity": 0,
+        "start": "2024-03-02T00:00:00Z",
+        "end": "2024-03-02T23:59:59Z"
+    }
+    test_client.post(f"/v2/volunteers/{user_id}/unavailability",
+                     json=payload
+                     )
     response = test_client.get(f"/v2/volunteers/{user_id}/unavailability")
-    # Assuming the system treats requests for non-existent users as bad requests or not found
-    assert response.status_code == 404
+    assert response.status_code == 404 # Assuming the system treats requests for non-existent users as bad requests
+    # or not found
     assert response.json == {"message": "User not found"}  # Assuming this is the response for an invalid user ID
-
-
-# This is not yet implemented in the get method
-def test_get_volunteer_unavailability_unauthorized(test_client):
-    user_id = 30
-    # This test assumes that the endpoint requires authentication and that the test client is not authenticated
-    response = test_client.get(f"/v2/volunteers/{user_id}/unavailability")
-    assert response.status_code == 401  # Unauthorized access
-    assert "error" in response.json  # Checking for an error message in the response
-
-
-# This is not yet implemented in the get method
-def test_get_volunteer_unavailability_forbidden(test_client):
-    user_id = 31
-    # Assuming the test client is authenticated as a different user without permissions to access this user's data
-    response = test_client.get(f"/v2/volunteers/{user_id}/unavailability")
-    assert response.status_code == 403  # Forbidden access
-    assert "error" in response.json  # Checking for an error message indicating lack of permissions

--- a/tests/functional/test_unavailability_get.py
+++ b/tests/functional/test_unavailability_get.py
@@ -1,0 +1,40 @@
+def test_get_volunteer_unavailability_success(test_client):
+    user_id = 6  # Assuming this user has at least one unavailability record
+    response = test_client.get(f"/v2/volunteers/{user_id}/unavailability")
+    assert response.status_code == 200
+    assert "unavailability" in response.json  # Assuming the response includes an 'unavailability' key
+    assert isinstance(response.json["unavailability"], list)  # Assuming the unavailability records are returned as a
+    # list
+
+
+def test_get_volunteer_unavailability_no_records(test_client):
+    user_id = 50  # Assuming this user has no unavailability records
+    response = test_client.get(f"/v2/volunteers/{user_id}/unavailability")
+    assert response.status_code == 400  # Assuming the endpoint returns a 400 status for no records found
+    assert response.json == {'userID': user_id, 'success': False}  # Expected response body for no records
+
+
+def test_get_volunteer_unavailability_invalid_user(test_client):
+    user_id = -1  # Non-existent user ID
+    response = test_client.get(f"/v2/volunteers/{user_id}/unavailability")
+    # Assuming the system treats requests for non-existent users as bad requests or not found
+    assert response.status_code == 404
+    assert response.json == {"message": "User not found"}  # Assuming this is the response for an invalid user ID
+
+
+# This is not yet implemented in the get method
+def test_get_volunteer_unavailability_unauthorized(test_client):
+    user_id = 30
+    # This test assumes that the endpoint requires authentication and that the test client is not authenticated
+    response = test_client.get(f"/v2/volunteers/{user_id}/unavailability")
+    assert response.status_code == 401  # Unauthorized access
+    assert "error" in response.json  # Checking for an error message in the response
+
+
+# This is not yet implemented in the get method
+def test_get_volunteer_unavailability_forbidden(test_client):
+    user_id = 31
+    # Assuming the test client is authenticated as a different user without permissions to access this user's data
+    response = test_client.get(f"/v2/volunteers/{user_id}/unavailability")
+    assert response.status_code == 403  # Forbidden access
+    assert "error" in response.json  # Checking for an error message indicating lack of permissions

--- a/tests/functional/test_unavailability_get.py
+++ b/tests/functional/test_unavailability_get.py
@@ -19,7 +19,7 @@ def test_get_volunteer_unavailability_no_records(test_client):
     test_client.post(f"/v2/volunteers/{user_id}/unavailability")
     response = test_client.get(f"/v2/volunteers/{user_id}/unavailability")
     assert response.status_code == 400  # Assuming the endpoint returns a 400 status for no records found
-    assert response.json == {'userID': user_id, 'success': False}  # Expected response body for no records
+    assert response.json == {"message": "No unavailability record found."}  # Expected response body for no records
 
 
 def test_get_volunteer_unavailability_invalid_user(test_client):


### PR DESCRIPTION
## Describe your changes
Deleted redundant tests to get vehicle list.
Made unit tests for the unavailability fetch (get) method.

Test 1: Success Retrieval of Unavailability Records
Objective: Verify that the system can successfully retrieve unavailability records for a volunteer with existing records.
Criteria:

- The response status code must be 200, indicating a successful request.
- The response must contain an 'unavailability' key, showing that unavailability data is being returned.
- The 'unavailability' key must be associated with a list, indicating one or more unavailability records are present.

Test 2: No Unavailability Records Found
Objective: Confirm the system's response when a valid volunteer has no unavailability records.
Criteria:
- The response status code should be 400, indicating a client-side error due to the absence of records.
- To inform the client about the lack of records, the response body must explicitly indicate failure, with a structure matching {'userID': user_id, 'success': False}.


Test 3: Invalid Volunteer User ID
Objective: Ensure the system correctly handles requests for non-existent users.
Criteria:
- The response status code should be 404, indicating that the requested resource (user or unavailability record) was not found.
- The response should include a message indicating the user was not found, making the error clear to the client.

Test 4: Unauthorized Access Attempt
Objective: Test the system's response to an unauthorized request by simulating a scenario in which the requestor is not authenticated.
Criteria:
- The response status code must be 401, signalling unauthorized access due to lack of or invalid authentication.
- The response must contain an error message, providing feedback that authentication is required.

Test 5: Forbidden Access Attempt
Objective: Validate the system's handling of requests from authenticated users who do not have permission to access the requested data.
Criteria:
- The response status code should be 403, indicating that the requestor is authenticated but lacks the necessary permissions to access the requested resource.
- The response must include an error message indicating the requestor's insufficient permissions.

## Issue ticket number and link
[Issue FE-146](https://fireapp-emergiq-2024.atlassian.net/browse/FE-146)
